### PR TITLE
Include rpi-rgb-led-matrix as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rpi-rgb-led-matrix"]
+	path = rpi-rgb-led-matrix
+	url = https://github.com/hzeller/rpi-rgb-led-matrix

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # -MMD: This option tells gcc or g++ to generate a .d file containing the dependencies for each .cpp or .c file.
 # 	    The .d file will list the source file and all the headers it depends on.
-# -MP:  This flag adds phony targets for each header file to avoid issues if the header is deleted. This prevents 
+# -MP:  This flag adds phony targets for each header file to avoid issues if the header is deleted. This prevents
 #       Make from throwing an error when it tries to rebuild based on a deleted header.
 
 CFLAGS=-Wall -Ofast -g -Wextra -Wno-unused-parameter -MMD -MP
@@ -13,7 +13,7 @@ BINARIES=ndpi
 # Where our library resides. You mostly only need to change the
 # RGB_LIB_DISTRIBUTION, this is where the library is checked out.
 
-RGB_LIB_DISTRIBUTION=../rpi-rgb-led-matrix
+RGB_LIB_DISTRIBUTION=rpi-rgb-led-matrix
 RGB_INCDIR=$(RGB_LIB_DISTRIBUTION)/include
 RGB_LIBDIR=$(RGB_LIB_DISTRIBUTION)/lib
 RGB_LIBRARY_NAME=rgbmatrix
@@ -25,6 +25,9 @@ all : $(BINARIES)
 ndpi : $(OBJECTS) $(RGB_LIBRARY)
 	$(CXX) $(OBJECTS) -o $@ $(LDFLAGS)
 
+$(RGB_LIBRARY) :
+	$(MAKE) -C $(RGB_LIB_DISTRIBUTION)
+
 %.o : %.cpp
 	$(CXX) -I$(RGB_INCDIR) $(CXXFLAGS) -c -o $@ $<
 
@@ -33,6 +36,7 @@ ndpi : $(OBJECTS) $(RGB_LIBRARY)
 
 clean:
 	rm -f $(OBJECTS) $(BINARIES) $(OBJECTS:.o=.d)
+
 
 -include $(OBJECTS:.o=.d)
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ all : $(BINARIES)
 ndpi : $(OBJECTS) $(RGB_LIBRARY)
 	$(CXX) $(OBJECTS) -o $@ $(LDFLAGS)
 
+.PHONY: $(RGB_LIBRARY)
 $(RGB_LIBRARY) :
 	$(MAKE) -C $(RGB_LIB_DISTRIBUTION)
 
@@ -41,4 +42,4 @@ clean:
 -include $(OBJECTS:.o=.d)
 
 FORCE:
-.PHONY: FORCE
+.PHONY: FORCE)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,29 @@
+# NightDriver-Pi
+
 This is an early checkin of the in-progress work to bring the NightDriver wifi client to the Pi for HUB75 matrices.
 
 It uses the rgb-matrix-rpi library to manage the actual matrix.  It then spins up a thread to receive color data packets in standard NightDriver format, which is basically a timestamp and color data, one CRGB object per pixel.  As those packets are received they are placed in a circular buffer.
 
 The main thread monitors the buffer, and when a frame is ready to be drawn, pulls it off and sends it to the matrix.
 
-Building:
+## Cloning and building
 
-The code expects you have enlisted in the rpi-matrix project as a peer folder of your enlistment, and that you’ve already built it, since NDPi links to its output lib:
-https://github.com/hzeller/rpi-rgb-led-matrix
+The code in this project uses [`rpi-rgb-led-matrix`](https://github.com/hzeller/rpi-rgb-led-matrix) as a dependency, which is included in this repository as a submodule. There are two ways to initialize this library when preparing the build of this repo's code:
 
-Run make in it, then run make in this, should “just work”.  Not that you can do a lot with it!  
+1. Include the git clone of `rpi-rgb-led-matrix` in the clone of this repo. For this, use the following command to clone this repo:
+
+   ```shell
+   git clone --recurse-submodules https://github.com/davepl/NightDriver-Pi.git
+   ```
+
+2. Initialize and update the `rpi-rgb-led-matrix` submodule after cloning NightDriver-Pi itself - for instance because you already cloned the latter before you read this. This can be done by running the following command after cloning this repo:
+
+   ```shell
+   git submodule update --init --recursive
+   ```
+
+If you use a development environment like VSCode to clone NightDriver-Pi, the cloning of `rpi-rgb-led-matrix` may well happen automatically.
+
+Building NightDriver-Pi and its dependency can simply be done by running `make` - not that you can do a lot with it!
+The build of `rpi-rgb-led-matrix` will be included when necessary.
 


### PR DESCRIPTION
This makes the rpi-rgb-led-matrix dependency a git submodule in this repository, and automates its build (`make`) when necessary. Instructions in the README for cloning and building have been updated accordingly.