### PR TITLE
Rework - change byte order access functions, LEDBuffer becomes a deque instead of a vector

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,6 +57,9 @@
         "typeinfo": "cpp",
         "condition_variable": "cpp",
         "mutex": "cpp",
-        "span": "cpp"
+        "span": "cpp",
+        "bitset": "cpp",
+        "fstream": "cpp",
+        "cinttypes": "cpp"
     }
 }

--- a/globals.h
+++ b/globals.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <bit>
 
 constexpr auto WIFI_COMMAND_PIXELDATA64 = 3;             // Wifi command with color data and 64-bit clock vals
 constexpr auto WIFI_COMMAND_PEAKDATA    = 4;             // Wifi command that delivers audio peaks
@@ -14,38 +15,37 @@ constexpr auto kDefaultChainLength        = 8;
 constexpr auto kDefualtRows               = 32;
 constexpr auto kDefaultColumns            = 64;
 constexpr auto kDefaultGPIOSlowdown       = 5;
-constexpr auto kDefaultRefreshRate        = 60;
+constexpr auto kDefaultRefreshRate        = 100;
 constexpr auto kDefaultDisableBusyWaiting = true;
 
 constexpr auto kIncomingSocketPort        = 49152;
 constexpr auto kMaxBuffers                = 500;
 
-#define NUM_LEDS (Rows * Columns * ChainLength)
-
 // Helpers for extracting values from memory in a system-independent way
 
 constexpr uint64_t ULONGFromMemory(const uint8_t * payloadData)
 {
-    return  (uint64_t)payloadData[7] << 56  |
-            (uint64_t)payloadData[6] << 48  |
-            (uint64_t)payloadData[5] << 40  |
-            (uint64_t)payloadData[4] << 32  |
-            (uint64_t)payloadData[3] << 24  |
-            (uint64_t)payloadData[2] << 16  |
-            (uint64_t)payloadData[1] << 8   |
-            (uint64_t)payloadData[0];
+    const auto result = *(uint64_t *)payloadData;
+    if constexpr (std::endian::native == std::endian::little) 
+        return result;                      // Already little-endian, no swap needed
+    else 
+        return __builtin_bswap64(result);   // Swap for big-endian systems
 }
 
 constexpr uint32_t DWORDFromMemory(const uint8_t * payloadData)
 {
-    return  (uint32_t)payloadData[3] << 24  |
-            (uint32_t)payloadData[2] << 16  |
-            (uint32_t)payloadData[1] << 8   |
-            (uint32_t)payloadData[0];
+    const auto result = *(uint32_t *)payloadData;
+    if constexpr (std::endian::native == std::endian::little) 
+        return result;                      // Already little-endian, no swap needed
+    else 
+        return __builtin_bswap32(result);   // Swap for big-endian systems
 }
 
 constexpr uint16_t WORDFromMemory(const uint8_t * payloadData)
 {
-    return  (uint16_t)payloadData[1] << 8   |
-            (uint16_t)payloadData[0];
+    const auto result = *(uint16_t *)payloadData;
+    if constexpr (std::endian::native == std::endian::little) 
+        return result;                      // Already little-endian, no swap needed
+    else 
+        return __builtin_bswap16(result);   // Swap for big-endian systems
 }

--- a/ledbuffer.h
+++ b/ledbuffer.h
@@ -54,7 +54,7 @@ class LEDBufferException : public std::runtime_error
 
 // LEDBuffer
 //
-// Represents a frame of LED data with a timestamp.  The data is a deque of CRGB objects.
+// Represents a frame of LED data with a timestamp.  The data is a vector of CRGB objects.
 // The timestamp is in seconds and microseconds since the epoch.
 
 class LEDBuffer

--- a/main.cpp
+++ b/main.cpp
@@ -21,17 +21,16 @@
 //
 // Description:
 //
-//    Hosts a socket server on port 49152 to receive LED data from the master
-//    and then draws that data to the LED matrix
+//    Hosts a socket server on port 49152 to receive LED data from a remote
+//    NightDriverDesktop instance and then draws that data to the LED matrix
 //
 // History:     Aug-14-2024     Davepl      Created from NightDriverStrip
 //---------------------------------------------------------------------------
 
-#include "led-matrix.h"
-
 #include <signal.h>
 #include "apptime.h"
 #include "globals.h"
+#include "led-matrix.h"
 #include "ledbuffer.h"
 #include "socketserver.h"
 #include "matrixdraw.h"
@@ -97,6 +96,7 @@ int main(int argc, char *argv[])
     	fprintf(stderr, "Error creating RGBMatrix object\n");
          	return 1;
     }   
+    matrix->set_luminance_correct(true);
 
     const auto maxLEDs = matrix->width() * matrix->height();
     printf("Matrix Size: %dx%d (%d LEDs)\n", matrix->width(), matrix->height(), maxLEDs);

--- a/socketserver.h
+++ b/socketserver.h
@@ -218,7 +218,7 @@ public:
     //
     // Read from the socket until the buffer contains at least cbNeeded bytes
 
-    bool ReadUntilNBytesReceived(size_t socket, size_t cbNeeded) const 
+    bool ReadUntilNBytesReceived(size_t socket, size_t cbNeeded) 
     {
         if (cbNeeded <= _cbReceived)                            // If we already have that many bytes, we're already done
             return true;


### PR DESCRIPTION
- Increases refresh rate to 100Hz for better display quality
- Reworks ULONGFromMemory and friends to use bswap and only where needed
- Changes the LEDBuffer collection from vector to deque
- Changes the LEDBuffer mutex from recursive to regular
- Removed IsEmpty proxy in favor of _buffer.empty to eliminate nested mutex case